### PR TITLE
Feature Request: Ignore certain error messages

### DIFF
--- a/tasks/html.js
+++ b/tasks/html.js
@@ -50,7 +50,7 @@ module.exports = function(grunt) {
           grunt.log.writeln('['.red + ('L' + loc[0]).yellow + ':'.red + ('C' + loc[2]).yellow + ']'.red + (parts[3]).yellow);
         }
       }
-      done(!!viols);
+      done(!viols);
     });
   });
 


### PR DESCRIPTION
I am using grunt-html to validate a set of HTML files which are actually HTML fragments, so I need to ignore certain messages.  I added an option called 'ignore', which accepts an array of messages to ignore.

Example usage:

``` javascript
grunt.initConfig({
    htmllint: {
        options: {
            ignore: [
                'Element "head" is missing a required instance of child element "title".',
                'Start tag seen without seeing a doctype first. Expected e.g. "<!DOCTYPE html>".'
            ]
        },
        all: ['content/**/*.html']
    }
});
```
