### PR TITLE
increase child process buffer size

### DIFF
--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -7,11 +7,16 @@ module.exports = function(config, done) {
 
   var maxChars = 5000;
 
+  // increase child process buffer to accommodate large amounts of 
+  // validation output. (default is a paltry 200k.)
+  // http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
+  var maxBuffer = 20000 * 1024;
+
   var files = config.files.join(' ');
   var chunks = [];
 
   async.mapSeries(chunkify(config.files, maxChars), function(chunk, cb) {
-    exec('java -jar ' + jar + ' --format json ' + chunk, function(error, stdout, stderr) {
+    exec('java -jar ' + jar + ' --format json ' + chunk, { 'maxBuffer' : maxBuffer }, function(error, stdout, stderr) {
        if (error) {
         cb(error);
         return;


### PR DESCRIPTION
When running `htmllint` on 100+ HTML files with lots of errors, I received a `stderr maxBuffer exceeded` error:

```
[11:27 PM]-[9577]-[justin@justin]-[~/projects/poses] (html-validation-fixes @ 058a7b9 ⚡ )
$ grunt htmllint
Running "htmllint:all" (htmllint) task
>> Error: stderr maxBuffer exceeded.
Warning: Task "htmllint:all" failed. Use --force to continue.

Aborted due to warnings.
```

Bummer!

According to [the child_process docs](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback),  `exec()` accepts an options hash that allows you to specify the `maxBuffer`. Increasing it 100x (20MB vs. the default 200KB) seemed to do the trick for me.

The only downside to this I can imagine is more memory usage. :shrugs: …worksforme!
