### PR TITLE
Consider maxBuffer in Chunkify

### DIFF
--- a/lib/chunkify.js
+++ b/lib/chunkify.js
@@ -1,18 +1,19 @@
 'use strict';
 
-function chunkify(files, maxChars) {
-  const fs = require("fs");
+function chunkify(files, maxBuffer) {
+  const fs = require('fs');
   const filesChunk = [];
   let chunk = '';
-  var chunkLen = 0;
+  let chunkLen = 0;
 
   for (let f = 0, len = files.length; f < len; f++) {
-    var stats = fs.statSync(files[ f ]);
-    if ( chunkLen + ( stats.size + 1 ) > maxBuffer ) {
+    const stats = fs.statSync(files[f]);
+    if (chunkLen + (stats.size + 1) > maxBuffer) {
       filesChunk.push(chunk.trim());
       chunk = '';
       chunkLen = 0;
     }
+
     chunkLen += stats.size;
     chunk += `"${files[f]}" `;
   }

--- a/lib/chunkify.js
+++ b/lib/chunkify.js
@@ -1,20 +1,29 @@
 'use strict';
 
-function chunkify(files, maxBuffer) {
+function chunkify(files, maxChars, maxBuffer) {
   const fs = require('fs');
   const filesChunk = [];
   let chunk = '';
   let chunkLen = 0;
+  let stats;
 
   for (let f = 0, len = files.length; f < len; f++) {
-    const stats = fs.statSync(files[f]);
-    if (chunkLen + (stats.size + 1) > maxBuffer) {
+    stats = undefined;
+
+    if (fs.existsSync(files[f])) {
+      stats = fs.statSync(files[f]);
+    }
+
+    if (chunk.length + (files[f].length + 1) > maxChars || (stats && (chunkLen + stats.size + 1 > maxBuffer))) {
       filesChunk.push(chunk.trim());
       chunk = '';
       chunkLen = 0;
     }
 
-    chunkLen += stats.size;
+    if (stats) {
+      chunkLen += stats.size;
+    }
+
     chunk += `"${files[f]}" `;
   }
 

--- a/lib/chunkify.js
+++ b/lib/chunkify.js
@@ -1,15 +1,19 @@
 'use strict';
 
 function chunkify(files, maxChars) {
+  const fs = require("fs");
   const filesChunk = [];
   let chunk = '';
+  var chunkLen = 0;
 
   for (let f = 0, len = files.length; f < len; f++) {
-    if (chunk.length + (files[f].length + 1) > maxChars) {
+    var stats = fs.statSync(files[ f ]);
+    if ( chunkLen + ( stats.size + 1 ) > maxBuffer ) {
       filesChunk.push(chunk.trim());
       chunk = '';
+      chunkLen = 0;
     }
-
+    chunkLen += stats.size;
     chunk += `"${files[f]}" `;
   }
 

--- a/lib/chunkify.js
+++ b/lib/chunkify.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const fs = require('fs');
 function chunkify(files, maxChars, maxBuffer) {
-  const fs = require('fs');
   const filesChunk = [];
   let chunk = '';
   let chunkLen = 0;

--- a/lib/chunkify.js
+++ b/lib/chunkify.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+
 function chunkify(files, maxChars, maxBuffer) {
   const filesChunk = [];
   let chunk = '';

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -92,7 +92,7 @@ function htmllint(config, done) {
 
     const files = config.files.map(path.normalize);
 
-    async.mapSeries(chunkify(files, MAX_CHARS), (chunk, cb) => {
+    async.mapSeries(chunkify(files, MAX_BUFFER), (chunk, cb) => {
       exec(cmd(java, chunk), { maxBuffer: MAX_BUFFER }, (error, stdout, stderr) => {
         if (error && (error.code !== 1 || error.killed || error.signal)) {
           cb(error);

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -8,6 +8,8 @@ const chunkify = require('./chunkify');
 const javadetect = require('./javadetect');
 
 function htmllint(config, done) {
+  const MAX_CHARS = 5000;
+
   // increase child process buffer to accommodate large amounts of
   // validation output. (the default is a paltry 200k)
   // https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
@@ -90,7 +92,7 @@ function htmllint(config, done) {
 
     const files = config.files.map(path.normalize);
 
-    async.mapSeries(chunkify(files, MAX_BUFFER), (chunk, cb) => {
+    async.mapSeries(chunkify(files, MAX_CHARS, MAX_BUFFER), (chunk, cb) => {
       exec(cmd(java, chunk), { maxBuffer: MAX_BUFFER }, (error, stdout, stderr) => {
         if (error && (error.code !== 1 || error.killed || error.signal)) {
           cb(error);

--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -8,8 +8,6 @@ const chunkify = require('./chunkify');
 const javadetect = require('./javadetect');
 
 function htmllint(config, done) {
-  const MAX_CHARS = 5000;
-
   // increase child process buffer to accommodate large amounts of
   // validation output. (the default is a paltry 200k)
   // https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback


### PR DESCRIPTION
Hi,

I came across a scenario when multiple files are inputed to `vnu.jar`, which overall side exceeding more than 20BM (with #24 ),

To fix this, I'm using maxBuffer also while chunkifying all input files to grunt task.
