### PR TITLE
lib/htmllint.js: use an Array for the Java command

### DIFF
--- a/lib/htmllint.js
+++ b/lib/htmllint.js
@@ -52,31 +52,34 @@ function parseErrorMessages(errors, config) {
 
 // Determine proper jarfile command and arguments
 function javaCmd(java, chunk, config) {
-  let args = '';
+  const args = [];
+
+  // Increase the default stack size for ia32 versions
+  if (java.arch === 'ia32') {
+    args.push('-Xss512k');
+  }
+
+  args.push(config.server ? '-cp' : '-jar', `"${jar}"`);
 
   if (config.server) {
     if (config.server.host) {
-      args += ` -Dnu.validator.client.host=${config.server.host}`;
+      args.push(`-Dnu.validator.client.host=${config.server.host}`);
     }
 
     if (config.server.port) {
-      args += ` -Dnu.validator.client.port=${config.server.port}`;
+      args.push(`-Dnu.validator.client.port=${config.server.port}`);
     }
 
-    args += ' -Dnu.validator.client.out=json nu.validator.client.HttpClient';
+    args.push('-Dnu.validator.client.out=json nu.validator.client.HttpClient');
   } else {
-    args += ' --format json';
+    args.push('--format', 'json');
   }
 
   if (config.noLangDetect) {
-    args += ' --no-langdetect';
+    args.push('--no-langdetect');
   }
 
-  const invoke = `${config.server ? '-cp' : '-jar'} "${jar}"${args}`;
-
-  // Command to call java, increasing the default stack size for ia32 versions of the JRE
-  // and using the default setting for x64 versions
-  return `java ${java.arch === 'ia32' ? '-Xss512k ' : ''}${invoke} ${chunk}`;
+  return ['java', ...args, chunk].join(' ');
 }
 
 function htmllint(config, done) {
@@ -96,9 +99,12 @@ function htmllint(config, done) {
     }
 
     const files = config.files.map(file => path.normalize(file));
+    const chunks = chunkify(files, MAX_CHARS);
 
-    async.mapSeries(chunkify(files, MAX_CHARS), (chunk, cb) => {
-      exec(javaCmd(java, chunk, config), { maxBuffer: MAX_BUFFER }, (error, stdout, stderr) => {
+    async.mapSeries(chunks, (chunk, cb) => {
+      const cmd = javaCmd(java, chunk, config);
+
+      exec(cmd, { maxBuffer: MAX_BUFFER }, (error, stdout, stderr) => {
         if (error && (error.code !== 1 || error.killed || error.signal)) {
           cb(error);
           return;


### PR DESCRIPTION
Rationale: we don't need to worry about whitespace between arguments and it will go well with the next PR I plan to open about switching to [`execFile`](https://github.com/validator/grunt-html/commit/9a40afd8fca4f896e20ba2b7d40dd5b4c9695a2d).