### PR TITLE
tests: add a test case for issue #152

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "c8": "^7.8.0",
+    "glob": "^7.1.7",
     "grunt": "^1.1.0",
     "mocha": "^9.1.1",
     "strip-ansi": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "c8": "^7.8.0",
-    "glob": "^7.1.7",
     "grunt": "^1.1.0",
     "mocha": "^9.1.1",
     "strip-ansi": "^6.0.0",

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const assert = require('assert').strict;
+const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
 const htmllint = require('../lib/htmllint.js');
 const expectedResults = require('./helpers/expected_results.js');
 
@@ -183,8 +183,13 @@ describe('htmllint', () => {
 
   describe('many files', () => {
     it('many files to test if results are overwritten', done => {
+      const dir = path.normalize('./test/fixtures/many-files/');
+      const files = fs.readdirSync(dir)
+        .filter(file => path.extname(file) === '.html')
+        .map(file => path.join(dir, file));
+
       const options = {
-        files: glob.sync('test/fixtures/many-files/*.html'),
+        files,
         errorlevels: ['info', 'warning', 'error']
       };
       const expected = ['001', '050', '100'].map(num => ({

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert').strict;
 const path = require('path');
+const glob = require('glob');
 const htmllint = require('../lib/htmllint.js');
 const expectedResults = require('./helpers/expected_results.js');
 
@@ -177,6 +178,24 @@ describe('htmllint', () => {
       const expected = [];
 
       run(options, expected, '0 errors from 0 files', done);
+    });
+  });
+
+  describe('many files', () => {
+    it('many files to test if results are overwritten', done => {
+      const options = {
+        files: glob.sync('test/fixtures/many-files/*.html'),
+        errorlevels: ['info', 'warning', 'error']
+      };
+      const expected = ['001', '050', '100'].map(num => ({
+        file: path.normalize(`test/fixtures/many-files/test-file-with-a-pretty-long-name-to-reach-maximum-length-sooner-${num}.html`),
+        type: 'error',
+        message: 'Element “title” must not be empty.',
+        lastLine: 3,
+        lastColumn: 15
+      }));
+
+      run(options, expected, '3 errors from 3 files', done);
     });
   });
 });


### PR DESCRIPTION
~~I used grunt since we already depend on it, but it's a little messy, I think...~~

~~Maybe I should try with the glob package or something similar?~~

~~EDIT: I went with glob. If anyone has any suggestion with use `fs.readdirSync()` or `fs.readdir` let me know. I mean, the folder only contains this specific test case's files only, but it probably needs more code.~~

I pushed a patch with `fs.readdirSync`, let me know what you find better.