### PR TITLE
Harden CI workflows: permissions, concurrency, and timeouts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,18 @@
 name: Lint
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   FORCE_COLOR: 2
@@ -10,6 +22,7 @@ jobs:
   run:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Clone repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,18 @@
 name: Tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request' }}
 
 env:
   FORCE_COLOR: 2
@@ -10,6 +22,10 @@ jobs:
   test:
     name: Node ${{ matrix.node }} - ${{ matrix.architecture }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: write # needed by coverallsapp/github-action to post check run status
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
- Add `permissions: contents: read` at workflow level to lint and test
- Add `permissions: checks: write` at job level in test (required by Coveralls)
- Add `concurrency` groups to cancel superseded runs
- Add `timeout-minutes` to all jobs to prevent runaway hangs